### PR TITLE
Remove duplicate trackedVariables from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ var trackedVariables = ["score", "hunger", "hasPetDog"];
 
 $(function() {
   $.getScript(url, function(data, textStatus, jqxhr) {
-    const trackedVariables = [];
     setupPlayfab(playfabID, trackedVariables, State);
   });
 });


### PR DESCRIPTION
Hi! I noticed the sample code snippet in the readme contains a superfluous `trackedVariables` declaration that shadows the other one. Probably won't have people stumped for too long but figured I could send a quick PR :)